### PR TITLE
Add a file to set up the Codespace environment

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,29 @@
+name: Verify
+on: [push]
+
+jobs:
+  linters:
+    name: Linters
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Run linters
+        uses: ludeeus/action-shellcheck@master
+
+  tests:
+    name: Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup SSH Keys and known_hosts
+        uses: webfactory/ssh-agent@v0.5.4
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
+      - name: Run script
+        run: sh install.sh

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# Install Unix dependencies
+sudo wget -q https://apt.thoughtbot.com/thoughtbot.gpg.key -O /etc/apt/trusted.gpg.d/thoughtbot.gpg
+echo "deb https://apt.thoughtbot.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/thoughtbot.list
+sudo apt-get update
+sudo apt-get install -y silversearcher-ag rcm tmux vim
+
+# Clone thoughtbot's dotfiles
+git clone --depth 1 git@github.com:thoughtbot/dotfiles.git ~/dotfiles
+git clone --depth 1 git@github.com:purinkle/dotfiles.git ~/dotfiles-local
+
+# Install the dotfiles
+env RCRC="$HOME/dotfiles/rcrc" rcup -f


### PR DESCRIPTION
Before, we didn't have any way of setting up a Codespace environment every time
we created one. We had to clone and run a script by hand. We added a file for
Codespace to set up the environment for us.

- Add a GitHub Action to verify the script.
